### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/gist.py
+++ b/gist.py
@@ -23,7 +23,7 @@ def plugin_loaded():
         settings.set('max_gists', 100)  # the URLs are not updated.
         sublime.status_message("Gist: GitHub API does not support a value of higher than 100")
 
-    MAX_GISTS = '?per_page=%d' % settings.get('max_gists')
+    MAX_GISTS = '?per_page={0:d}'.format(settings.get('max_gists'))
 
     api_url = settings.get('api_url')  # Should add validation?
     settings.set('GISTS_URL', api_url + '/gists' + MAX_GISTS)
@@ -184,10 +184,10 @@ class GistCommand(sublime_plugin.TextCommand):
                 else:
                     if filename:
                         (namepart, extpart) = os.path.splitext(filename)
-                        make_filename = lambda num: "%s (%d)%s" % (namepart, num, extpart)
+                        make_filename = lambda num: "{0!s} ({1:d}){2!s}".format(namepart, num, extpart)
                     else:
                         syntax_name, _ = os.path.splitext(os.path.basename(self.view.settings().get('syntax')))
-                        make_filename = lambda num: "%s %d" % (syntax_name, num)
+                        make_filename = lambda num: "{0!s} {1:d}".format(syntax_name, num)
                     gist_data = dict((make_filename(idx), data) for idx, data in enumerate(region_data, 1))
 
                 gist = create_gist(self.public, description, gist_data)
@@ -197,7 +197,7 @@ class GistCommand(sublime_plugin.TextCommand):
 
                 gist_html_url = gist['html_url']
                 sublime.set_clipboard(gist_html_url)
-                sublime.status_message("%s Gist: %s" % (self.mode(), gist_html_url))
+                sublime.status_message("{0!s} Gist: {1!s}".format(self.mode(), gist_html_url))
 
                 if gistify:
                     gistify_view(self.view, gist, list(gist['files'].keys())[0])

--- a/helpers.py
+++ b/helpers.py
@@ -10,7 +10,7 @@ def gistify_view(view, gist, gist_filename):
     if not view.file_name():
         view.set_name(gist_filename)
     elif os.path.basename(view.file_name()) != gist_filename:
-        statusline_string = "%s (%s)" % (statusline_string, gist_filename)
+        statusline_string = "{0!s} ({1!s})".format(statusline_string, gist_filename)
 
     view.settings().set('gist_html_url', gist["html_url"])
     view.settings().set('gist_description', gist['description'])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:Gist?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:Gist?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
